### PR TITLE
Add archive.org magazine scans as sources, dropping sffaudio.com pdfs.

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -29,15 +29,15 @@
 		<dc:description id="description">A barbarian adventures through ancient civilizations and battles fearsome enemies in this collection of Conan the Cimmerian short stories.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;Conan, the Cimmerian barbarian, romps across the pages of Robert &lt;abbr&gt;E.&lt;/abbr&gt; Howard’s Hyborian adventures, slicing down enemy after enemy and trying not to fall too hard for a succession of ladies in need of rescue. Although very much a product of the pulp fantasy magazines of the 1930s, Conan has surpassed his contemporaries to become the quintessential barbarian of the fantasy genre: the muscle-bound and instinct-led hero, always willing to fight his way out of any fix.&lt;/p&gt;
-			&lt;p&gt;Collected here are all ten available public domain Conan stories and the history of Hyboria that Howard wrote as a guide for himself to write from. &lt;i&gt;Gods of the North&lt;/i&gt; originally was a Conan story, but after being rejected by the first publisher was rewritten slightly to a character called Amra; it was later republished as &lt;i&gt;The Frost-Giant’s Daughter&lt;/i&gt; with the name changed back. The stories were serialised (with a couple of exceptions) in &lt;i&gt;Weird Tales&lt;/i&gt; magazine between 1934 and 1936, and have gone on to spawn multiple licensed and unlicensed sequels, comics, films and games.&lt;/p&gt;
+			&lt;p&gt;Collected here are all ten available public domain Conan short stories and the history of Hyboria that Howard wrote as a guide for himself to write from. &lt;i&gt;Gods of the North&lt;/i&gt; originally was a Conan story, but after being rejected by the first publisher was rewritten slightly to a character called Amra; it was later republished as &lt;i&gt;The Frost-Giant’s Daughter&lt;/i&gt; with the name changed back. The stories were serialised (with a couple of exceptions) in &lt;i&gt;Weird Tales&lt;/i&gt; magazine between 1934 and 1936, and have gone on to spawn multiple licensed and unlicensed sequels, comics, films and games.&lt;/p&gt;
 		</meta>
 		<dc:language>en-US</dc:language>
 		<!-- Gods of the North (The Fantasy Fan, March 1934) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42664</dc:source>
-		<dc:source>http://www.sffaudio.com/podcasts/Gods%20Of%20The%20North%20by%20Robert%20E.%20Howard.pdf</dc:source>
+		<dc:source>https://archive.org/details/Fantastic_Universe_v06n05_1956-12</dc:source>
 		<!-- Shadows in the Moonlight (Weird Tales, April 1934) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42188</dc:source>
-		<!-- scans not yet found -->
+		<dc:source>https://archive.org/details/WeirdTales193404damagedIBCATLPM</dc:source>
 		<!-- Queen of the Black Coast (Weird Tales, May 1934) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42183</dc:source>
 		<dc:source>https://archive.org/details/Weird_Tales_v23n05_1934-05_sas</dc:source>
@@ -47,7 +47,8 @@
 		<!-- The People of the Black Circle (Weird Tales, September–November 1934) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42259</dc:source>
 		<dc:source>https://archive.org/details/Weird_Tales_v24n03_1934-09</dc:source>
-		<dc:source>http://www.sffaudio.com/podcasts/ThePeopleOfTheBlackCircleByRobertE.Howard.pdf</dc:source>
+		<dc:source>https://archive.org/details/WeirdTalesV24N04193410saspages4856Damaged</dc:source>
+		<dc:source>https://archive.org/details/WeirdTales193411ATLPM</dc:source>
 		<!-- A Witch Shall Be Born (Weird Tales, December 1934) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42227</dc:source>
 		<dc:source>https://archive.org/details/Weird_Tales_v24n06_1934-12_sas</dc:source>
@@ -60,7 +61,7 @@
 		<dc:source>https://archive.org/details/Weird_Tales_v25n06_1935-06_sas</dc:source>
 		<!-- Shadows in Zamboula (Weird Tales, November 1935) -->
 		<dc:source>https://www.gutenberg.org/ebooks/42196</dc:source>
-		<!-- scans not yet found -->
+		<dc:source>https://archive.org/details/WeirdTales193511ATLPM</dc:source>
 		<!-- Red Nails (Weird Tales, July-October 1936) -->
 		<dc:source>https://www.gutenberg.org/ebooks/32759</dc:source>
 		<dc:source>https://archive.org/details/Weird_Tales_v28n01_1936-07_sas</dc:source>


### PR DESCRIPTION
I have found scans for "Gods of the North" (not the original *The Fantasy Fan* publication, unfortunately, but a reprint from *Fantastic Universe* which PG used), "Shadows in the Moonlight", "The People of the Black Circle", and "Shadows in Zamboula", and added them as sources in the content.opf file. I wasn't able to find scans of "The Hyborian Age", unfortunately.

I've also dropped the sffaudio.com links, since they are not as useful as the archive.org scans and much more likely to disappear in years to come. I'm happy to re add them if we want though.

Finally, I've made a minor addition to the description to specif that this is only the short stories, as there is one novel on Project Gutenberg available; also there's good evidence that the rest of the Conan short stories are in the public domain and we should be able to add them sooner than their 95th birthday.